### PR TITLE
Add license texts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+Copyright 2022. Cognite AS.
+
+This is the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # What?
 
-This repository has examples of to reliably sync changes out of Postgres and into external systems.
+This repository has examples of to reliably sync changes out of
+Postgres and into external systems.
 
-It supports the talk "Flexible change data capture with Postgres". A link to a recording of that talk will be provided here when the recording is available.
+It supports the talk "Flexible change data capture with Postgres". A
+link to a recording of that talk will be provided here when the
+recording is available.
 
 # Background material
 
-This code assumes understanding a bit of Postgres' multi-version concurrency control (MVCC) internals, particularly how snapshots and visibility works.
+This code assumes understanding a bit of Postgres' multi-version
+concurrency control (MVCC) internals, particularly how snapshots and
+visibility works.
 
 The following material is worth checking out to learn more about MVCC:
 
@@ -15,14 +20,23 @@ The following material is worth checking out to learn more about MVCC:
 
 # How?
 
-Assuming you have Postgres >=12 running somewhere, do something like `createdb sync-test; psql sync-test -f apply-schema.sql`. Set the env var `POSTGRES_CONFIG` if you need to configure host, username, etc.
+Assuming you have Postgres >=12 running somewhere, do something like
+`createdb sync-test; psql sync-test -f apply-schema.sql`. Set the env
+var `POSTGRES_CONFIG` if you need to configure host, username, etc.
 
-Configurability hasn't been a priority, so things assume the database is called "sync-test", so grep for that and replace or just call it that.
+Configurability hasn't been a priority, so things assume the database
+is called "sync-test", so grep for that and replace or just call it
+that.
 
-You'll need python3 and the stuff in requirements.txt, e.g. via `pip3 install -r requirements.txt`.
+You'll need python3 and the stuff in requirements.txt, e.g. via `pip3
+install -r requirements.txt`.
 
 * `demo-app.py` will provide a tiny API that provides bulks of changes and a cursor.
 * `load-generator.py` generates random transactions that commit out of order. This load would cause naïve syncing based on timestamps to fail pretty quickly.
 * `sqlite-via-api-client.py` uses the small API to sync all the data into SQLite.
 * `consistency-check.py` verifies that everything in Postgres has been copied into SQLite without any differences. It is expected to find differences while load-generator is running.
 
+# Licence
+
+This code sample is licenced under the MIT open source licence, and
+Copyright 2022 Cognite AS


### PR DESCRIPTION
Since the code samples will quickly be used individually, we add explicit licences.

Also reformatted some text.